### PR TITLE
#29-beginner: Move segmented control to top.

### DIFF
--- a/LiveWeather/LocationWeather/LocationWeatherView.swift
+++ b/LiveWeather/LocationWeather/LocationWeatherView.swift
@@ -42,9 +42,8 @@ class LocationWeatherView: UIView {
     lazy var segmentControl: UISegmentedControl = UISegmentedControl()
 
 	lazy var vStack: UIStackView = UIStackView(arrangedSubviews:
-		[self.selectedLocationTitle, self.hStackForTimeStamp, self.hStackForWeatherState,
-		self.hStackForTemperature, self.hStackForHumidity, self.hStackForWindSpeed,
-		self.segmentControl])
+		[self.segmentControl, self.selectedLocationTitle, self.hStackForTimeStamp, self.hStackForWeatherState,
+		self.hStackForTemperature, self.hStackForHumidity, self.hStackForWindSpeed])
 
     var segmentTitles: [String] = []
 	weak var delegate: LocationWeatherViewDelegate?


### PR DESCRIPTION
The repo had a great image in the `App Architecture Overview` section. That image showed us that LocationWeatherView is the only view.

In that file, I looked for the init and then went to configure subviews, and finally to the vStack declaration. There, it was simple enough to move the segmentControl from the end of the `arrangedSubviews` array to the beginning.